### PR TITLE
Ensure cached images are refreshed periodically

### DIFF
--- a/pkg/multi-cluster/puller.go
+++ b/pkg/multi-cluster/puller.go
@@ -76,8 +76,8 @@ func cacheImagesForUser(impersonateUser string,
 			wg.Done()
 		case <-time.After(time.Duration(cfg.CachingInterval) * time.Hour):
 			log.Printf("Checking daemonset for user '%s'", impersonateUser)
+			utils.RefreshCache(clientset)
 			utils.LogNumNodesScheduled(clientset, impersonateUser)
-			utils.EnsureDaemonsetExists(clientset)
 		}
 	}
 }

--- a/pkg/single-cluster/puller.go
+++ b/pkg/single-cluster/puller.go
@@ -45,7 +45,7 @@ func cacheImagesLocally(config *rest.Config,
 	utils.DeleteDaemonsetIfExists(clientset)
 	// Create daemonset to cache images
 	utils.CacheImages(clientset)
-	utils.LogNumNodesScheduled(clientset, "")
+	utils.LogNumNodesScheduled(clientset, "(single user mode)")
 
 	for {
 		select {
@@ -54,8 +54,8 @@ func cacheImagesLocally(config *rest.Config,
 			utils.DeleteDaemonsetIfExists(clientset)
 			wg.Done()
 		case <-time.After(time.Duration(cfg.CachingInterval) * time.Hour):
-			utils.LogNumNodesScheduled(clientset, "")
-			utils.EnsureDaemonsetExists(clientset)
+			utils.RefreshCache(clientset)
+			utils.LogNumNodesScheduled(clientset, "(single user mode)")
 		}
 	}
 }

--- a/utils/operations.go
+++ b/utils/operations.go
@@ -29,6 +29,15 @@ func CacheImages(clientset *kubernetes.Clientset) {
 	log.Printf("Daemonset ready.")
 }
 
+// RefreshCache forces a refresh of all pods in the daemonset, to ensure images
+// with mutable tags (e.g. nightlies) are up-to-date.
+func RefreshCache(clientset *kubernetes.Clientset) {
+	log.Printf("Refreshing cached images")
+	DeleteDaemonsetIfExists(clientset)
+	createDaemonset(clientset)
+	log.Printf("Refreshed images")
+}
+
 // EnsureDaemonsetExists checks that the daemonset is still present, and
 // recreates it if necessary
 func EnsureDaemonsetExists(clientset *kubernetes.Clientset) {


### PR DESCRIPTION
### What does this PR do?

Instead of just checking daemonset health every CACHING_INTERVAL, instead recreate the deamonset to ensure each image is re-pulled. This is required for caching mutable image tags, such as latest or nightly.

Also changes "wait" operations to report if the channel is closed prematurely.

### What issue does this PR resolve?
https://github.com/redhat-developer/rh-che/issues/1549