### PR TITLE
Clean up unnecessary fields in deployment yamls

### DIFF
--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -22,12 +22,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    creationTimestamp: 2019-04-04T23:20:55Z
     name: create-daemonset
-    namespace: daemonset-test
-    resourceVersion: "1516348"
-    selfLink: /apis/rbac.authorization.k8s.io/v1/namespaces/daemonset-test/rolebindings/daemonset-binding
-    uid: 4c14fe24-5730-11e9-8bed-5254005a8b42
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role

--- a/openshift/serviceaccount.yaml
+++ b/openshift/serviceaccount.yaml
@@ -22,12 +22,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    creationTimestamp: 2019-04-04T23:20:55Z
     name: create-daemonset
-    namespace: daemonset-test
-    resourceVersion: "1516348"
-    selfLink: /apis/rbac.authorization.k8s.io/v1/namespaces/daemonset-test/rolebindings/daemonset-binding
-    uid: 4c14fe24-5730-11e9-8bed-5254005a8b42
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role


### PR DESCRIPTION
Cleanup fields in yamls that accidentally made it in there from a `oc get -o yaml`