### PR TITLE
Add additional readiness check for when watch fails and support NodeSelector

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -25,6 +25,7 @@ var (
 	CachingMemLimit      string
 	CachingInterval      int
 	MultiCluster         bool
+	NodeSelector         map[string]string
 )
 
 func init() {
@@ -40,4 +41,5 @@ func init() {
 	CachingMemRequest = getEnvVarOrDefault(cachingMemRequestEnvVar, defaultCachingMemRequest)
 	CachingMemLimit = getEnvVarOrDefault(cachingMemLimitEnvVar, defaultCachingMemLimit)
 	MultiCluster = getEnvVarOrDefaultBool(multiCluster, defaultMultiCluster)
+	NodeSelector = processNodeSelectorEnvVar()
 }

--- a/cfg/envvars.go
+++ b/cfg/envvars.go
@@ -13,6 +13,7 @@
 package cfg
 
 import (
+	"encoding/json"
 	"log"
 	"os"
 	"strconv"
@@ -33,6 +34,7 @@ const (
 	cachingMemRequestEnvVar    = "CACHING_MEMORY_REQUEST"
 	cachingMemLimitEnvVar      = "CACHING_MEMORY_LIMIT"
 	multiCluster               = "MULTICLUSTER"
+	nodeSelectorEnvVar         = "NODE_SELECTOR"
 )
 
 // Default values where applicable
@@ -43,6 +45,7 @@ const (
 	defaultCachingMemLimit   = "5Mi"
 	defaultCachingInterval   = 1
 	defaultMultiCluster      = true
+	defaultNodeSelector      = "{}"
 )
 
 func getCachingInterval() int {
@@ -83,6 +86,16 @@ func processImagesEnvVar() map[string]string {
 		imagesMap[nameAndImage[0]] = nameAndImage[1]
 	}
 	return imagesMap
+}
+
+func processNodeSelectorEnvVar() map[string]string {
+	rawNodeSelector := getEnvVarOrDefault(nodeSelectorEnvVar, defaultNodeSelector)
+	nodeSelector := make(map[string]string)
+	err := json.Unmarshal([]byte(rawNodeSelector), &nodeSelector)
+	if err != nil {
+		log.Fatalf("Failed to unmarshal node selector json: %s", err)
+	}
+	return nodeSelector
 }
 
 func processImpersonateUsers() []string {

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -19,3 +19,4 @@ data:
   SERVICE_ACCOUNT_ID: "ignored"
   SERVICE_ACCOUNT_SECRET: "ignored"
   MULTICLUSTER: "false"
+  NODE_SELECTOR: "{}"

--- a/openshift/configmap.yaml
+++ b/openshift/configmap.yaml
@@ -16,3 +16,4 @@ data:
   IMPERSONATE_USERS: "osio-ci-ee3-preview"
   CACHING_MEMORY_REQUEST: "1Mi"
   CACHING_MEMORY_LIMIT: "5Mi"
+  NODE_SELECTOR: "{}"

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -63,6 +63,7 @@ func createDaemonset(clientset *kubernetes.Clientset) error {
 					Name: "test-po",
 				},
 				Spec: corev1.PodSpec{
+					NodeSelector:                  cfg.NodeSelector,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					Containers:                    getContainers(),
 				},


### PR DESCRIPTION
### What does this PR do?
This PR is broken up into two commits:
1. Add a looping check to track daemonset status for when the daemonset watch is closed before all nodes are scheduled
2. Add support for specifying a NodeSelector for pods created by the daemonset, to allow e.g. only attempting to schedule on compute nodes.

In production, the configmap will need to be updated to set `NODE_SELECTOR: '{"type":"compute"}'`

### What issues does this PR fix?
https://github.com/redhat-developer/rh-che/issues/1580, https://github.com/redhat-developer/rh-che/issues/1579