### PR TITLE
Increase timeout on manual startup tracking to 90 seconds

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -5,7 +5,6 @@ metadata:
 type: Opaque
 data:
   IMAGES: >
-    jwtproxy=eclipse/che-jwtproxy:latest;
     java11-maven=quay.io/eclipse/che-java11-maven:nightly;
     che-theia=eclipse/che-theia:7.0.0;
     java-plugin-runner=eclipse/che-remote-plugin-runner-java8:7.0.0;

--- a/openshift/configmap.yaml
+++ b/openshift/configmap.yaml
@@ -5,7 +5,6 @@ metadata:
 type: Opaque
 data:
   IMAGES: >
-    jwtproxy=eclipse/che-jwtproxy:latest;
     java11-maven=quay.io/eclipse/che-java11-maven:nightly;
     che-theia=eclipse/che-theia:7.0.0;
     java-plugin-runner=eclipse/che-remote-plugin-runner-java8:7.0.0;

--- a/utils/clusterutils.go
+++ b/utils/clusterutils.go
@@ -115,8 +115,8 @@ func waitDaemonsetReady(c <-chan watch.Event) error {
 }
 
 func checkDaemonsetReadiness(clientset *kubernetes.Clientset) {
-	// Loop 10 times, sleeping for 3 seconds each time
-	for i := 0; i < 10; i++ {
+	// Loop 30 times, sleeping for 3 seconds each time -- 90 seconds total wait.
+	for i := 0; i < 30; i++ {
 		ds, err := clientset.AppsV1().DaemonSets(cfg.Namespace).Get(cfg.DaemonsetName, metav1.GetOptions{
 			// IncludeUninitialized: true,
 		})


### PR DESCRIPTION
Increase time for manual pod startup checking to 90 seconds to hopefully accommodate slower pulls.

Also remove jwtproxy from cached images, as it requires a volume mount to work (issue only reproduces on starter clusters).
