### PR TITLE
Potential fix for CI issue (cannot convert int64 to string)

### DIFF
--- a/openshift/app.yaml
+++ b/openshift/app.yaml
@@ -25,7 +25,7 @@ objects:
       spec:
         containers:
         - name: kubernetes-image-puller
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: "${IMAGE}:${IMAGE_TAG}"
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:


### PR DESCRIPTION
Not sure if this will work, but the last CI failed with `cannot convert int64 to string` error - https://ci.centos.org/job/devtools-kubernetes-image-puller-build-master/30/console